### PR TITLE
fix: channel-not-found error from teamJoin event handler

### DIFF
--- a/app.js
+++ b/app.js
@@ -86,17 +86,12 @@ app.action('learn_something_else', async ({ ack, say }) => {
   theActions.learn_something_else(say);
 });
 
-// *****************PROJECTBOT CHANNEL FOR TESTING****************************/
-
-app.event('member_joined_channel', async ({ event, client, logger }) => {
-  memberJoinChannel.memberJoin(event, client, logger);
-});
-
 //****************************************** */
 
 // When a user joins the team, the bot sends a DM to the newcommer asking them how they would like to contribute
 app.event('team_join', async ({ event, client, logger }) => {
-  joinTeam.joinTeamSlack(event, client, logger);
+  joinTeam.joinTeamSlack(event, client, logger); // this is the function that sends the DM
+  memberJoinChannel.memberJoin(event, client, logger); // this is for the #projectbot channel
 });
 
 //*********************************************************** */

--- a/components/joinChannel.js
+++ b/components/joinChannel.js
@@ -1,24 +1,24 @@
-const testChannel = 'C03D3L8TNMD';
+const testChannel = "C03D3L8TNMD";
 
 async function memberJoin(event, client, logger) {
-  try {
-    console.log(event);
-    return await client.chat.postMessage({
-      channel: testChannel,
+	try {
+		return await client.chat.postMessage({
+			channel: testChannel,
       blocks: [
         {
           type: 'section',
           text: {
             type: 'mrkdwn',
-            text: `Welcome to the team, <@${event.user}>! 🎉.`,
+            text: `Welcome to the team, <@${event.user.id}>! 🎉.`,
           },
         },
       ],
-    });
-  } catch (error) {
-    console.log(error);
-    logger.error(error);
-  }
+			text: `Welcome to the team, <@${event.user.id}>! 🎉.`,
+		});
+	} catch (error) {
+		console.log(error);
+		logger.error(error);
+	}
 }
 
 exports.memberJoin = memberJoin;

--- a/components/joinTeam.js
+++ b/components/joinTeam.js
@@ -1,14 +1,14 @@
 async function joinTeamSlack(event, client, logger) {
   try {
-    console.log(event);
+    console.log("join team: ",event);
     return await client.chat.postMessage({
-      channel: event.user,
+      channel: event.user.id,
       blocks: [
         {
           type: 'section',
           text: {
             type: 'mrkdwn',
-            text: `Welcome to *CHAOSS Community* <@${event.user}>! 🎉How would you like to get started? \n\nI want to..`,
+            text: `Welcome to *CHAOSS Community* <@${event.user.id}>! 🎉How would you like to get started? \n\nI want to..`,
           },
         },
         {
@@ -140,7 +140,7 @@ async function joinTeamSlack(event, client, logger) {
           ],
         },
       ],
-      text: `Welcome to the team, <@${event.user}>! 🎉.`,
+      text: `Welcome to the team, <@${event.user.id}>! 🎉.`,
     });
   } catch (error) {
     console.log(error);


### PR DESCRIPTION
Tested the bot and it was throwing a "channel not found" error whenever a new member joined, instead of sending the DM. After logging to the console, I discovered the ```event.user``` was returning an object. I fixed it by changing it to ```event.user.id```

Signed-off-by: Precious Abubakar <preciousdanabubakar@gmail.com>